### PR TITLE
Settings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod menu;
+mod settings;
 mod sound;
 mod storage;
 mod timers;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,6 +3,12 @@ use serde_json;
 
 pub const SETTINGS_VERSION: &str = "0.1";
 
+/// The `Settings` struct holds all the settings which will be saved and loaded
+/// from a file.
+///
+/// These settings give persistence between sessions, such as the amount of
+/// time the user should work, as well as the amount of time the user should
+/// have a break.
 #[derive(Serialize, Deserialize)]
 pub struct Settings {
     // Once new features are added, the version will increment. Thus, breaking
@@ -13,6 +19,16 @@ pub struct Settings {
 }
 
 impl Settings {
+    /// Creates a new instance of the `Settings` struct.
+    ///
+    /// ## Arguments
+    /// - work_time: The amount of time the work session lasts.
+    /// - break_time: The amount of time the break session lasts.
+    ///
+    /// ## Returns
+    /// A new `Settings` instance where the version of the settings, is the one
+    /// which is set in the `SETTINGS_VERSION` const. As well as the break
+    /// and work time specified in the arguments.
     pub fn new(work_time: u64, break_time: u64) -> Self {
         let settings = Self {
             version: SETTINGS_VERSION.to_string(),
@@ -22,10 +38,13 @@ impl Settings {
         settings
     }
 
+    /// Using serde, converts a the `Session` instance to a string.
     pub fn to_json(&self) -> String {
         serde_json::to_string(&self).unwrap()
     }
 
+    /// Using serde, returns a `Session` instance from a string, if it can be
+    /// deserialized. Otherwise, it returns `None`.
     pub fn from_json(string: &str) -> Option<Self> {
         serde_json::from_str(string).ok()
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use serde_json;
+
+pub const SETTINGS_VERSION: &str = "0.1";
+
+#[derive(Serialize, Deserialize)]
+pub struct Settings {
+    // Once new features are added, the version will increment. Thus, breaking
+    // changes can be mitigated, as to not cause a disaster.
+    pub version: String,
+    pub work_time: u64,
+    pub break_time: u64,
+}
+
+impl Settings {
+    pub fn new(work_time: u64, break_time: u64) -> Self {
+        let settings = Self {
+            version: SETTINGS_VERSION.to_string(),
+            work_time,
+            break_time,
+        };
+        settings
+    }
+
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+
+    pub fn from_json(string: &str) -> Option<Self> {
+        serde_json::from_str(string).ok()
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,7 +9,7 @@ pub const SETTINGS_VERSION: &str = "0.1";
 /// These settings give persistence between sessions, such as the amount of
 /// time the user should work, as well as the amount of time the user should
 /// have a break.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Settings {
     // Once new features are added, the version will increment. Thus, breaking
     // changes can be mitigated, as to not cause a disaster.
@@ -47,5 +47,21 @@ impl Settings {
     /// deserialized. Otherwise, it returns `None`.
     pub fn from_json(string: &str) -> Option<Self> {
         serde_json::from_str(string).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_settings_to_json_and_back() {
+        let settings = Settings::new(25, 5);
+
+        let json_str = settings.to_json();
+
+        let deserialized_settings = Settings::from_json(&json_str).expect("Invalid JSON");
+
+        assert_eq!(settings, deserialized_settings);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 pub const SETTINGS_VERSION: &str = "0.1";
 
@@ -30,12 +29,11 @@ impl Settings {
     /// which is set in the `SETTINGS_VERSION` const. As well as the break
     /// and work time specified in the arguments.
     pub fn new(work_time: u64, break_time: u64) -> Self {
-        let settings = Self {
+        Self {
             version: SETTINGS_VERSION.to_string(),
             work_time,
             break_time,
-        };
-        settings
+        }
     }
 
     /// Using serde, converts a the `Session` instance to a string.

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -3,6 +3,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use std::thread;
 use std::time::Duration;
 
+use crate::settings::Settings;
 use crate::sound::*;
 use crate::storage::Session;
 use crate::storage::SessionList;

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -3,7 +3,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use std::thread;
 use std::time::Duration;
 
-use crate::settings::Settings;
 use crate::sound::*;
 use crate::storage::Session;
 use crate::storage::SessionList;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -38,7 +38,13 @@ fn load_settings() -> Settings {
 
     let contents = storage.read().unwrap_or_else(|_| {
         let settings = Settings::new(25, 5);
-        storage.write(None, settings.to_json());
+        match storage.write(None, settings.to_json()) {
+            Ok(_) => (),
+            Err(v) => panic!(
+                "An error occured while writing the settings to the settings file: {}",
+                v
+            ),
+        }
 
         format!(
             "Could not read the contents of {}, creating a new file.",
@@ -50,9 +56,7 @@ fn load_settings() -> Settings {
         return Settings::new(25, 5);
     }
 
-    let settings = Settings::from_json(&contents).expect("Could not parse the contents of file.");
-
-    settings
+    Settings::from_json(&contents).expect("Could not parse the contents of file.")
 }
 
 pub fn ui_loop() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use crate::{
     menu,
+    settings::Settings,
     storage::{SessionList, Storage},
     timers::{self, Timer},
 };
@@ -29,11 +30,37 @@ fn load_sessions() -> SessionList {
     sessions
 }
 
+fn load_settings() -> Settings {
+    let folder = String::from(".tomato");
+    let file_name = String::from("settings.json");
+
+    let storage = Storage::new(Some(folder), file_name.clone());
+
+    let contents = storage.read().unwrap_or_else(|_| {
+        let settings = Settings::new(25, 5);
+        storage.write(None, settings.to_json());
+
+        format!(
+            "Could not read the contents of {}, creating a new file.",
+            file_name
+        )
+    });
+
+    if contents.is_empty() {
+        return Settings::new(25, 5);
+    }
+
+    let settings = Settings::from_json(&contents).expect("Could not parse the contents of file.");
+
+    settings
+}
+
 pub fn ui_loop() {
     let mut sessions = load_sessions();
+    let mut settings = load_settings();
 
     loop {
-        if ui(&mut sessions) == 9 {
+        if ui(&mut sessions, &mut settings) == 9 {
             break;
         }
     }
@@ -56,7 +83,7 @@ fn get_number_from_input() -> u64 {
     }
 }
 
-fn user_input(timer: &mut Timer) {
+fn user_input(timer: &mut Timer, settings: &mut Settings) {
     // time input for timer time
     println!("How long should the Pomodoro timer last?");
     println!("Please input in minutes: ");
@@ -69,17 +96,24 @@ fn user_input(timer: &mut Timer) {
 
     let input_break: u64 = get_number_from_input();
 
-    timer.work_minutes = input_work;
-    timer.break_minutes = input_break;
-
     timer.set_work_minutes(input_work);
     timer.set_break_minutes(input_break);
+
+    let file_name = String::from("settings.json");
+    let settings_storage = Storage::new(None, file_name);
+
+    settings.work_time = input_work;
+    settings.break_time = input_break;
+
+    settings_storage
+        .write(None, settings.to_json())
+        .expect("Something went wrong while trying to write to settings.json");
 }
 
-fn ui(session_list: &mut SessionList) -> u64 {
+fn ui(session_list: &mut SessionList, settings: &mut Settings) -> u64 {
     let total_minutes = session_list.total_work_minutes();
 
-    let mut timer = Timer::new(25, 5, total_minutes);
+    let mut timer = Timer::new(settings.work_time, settings.break_time, total_minutes);
 
     loop {
         menu::print_menu();
@@ -102,7 +136,7 @@ fn ui(session_list: &mut SessionList) -> u64 {
         match input {
             1 => {
                 //time_tup =
-                user_input(&mut timer);
+                user_input(&mut timer, settings);
                 println!("Work and break timers set.\n");
             }
             2 => {


### PR DESCRIPTION
This allows for the break and work timer duration to be persistent through sessions.

This closes #4.