### PR TITLE
Trait for Json Serialization and Deserialization

### DIFF
--- a/src/json_serializable.rs
+++ b/src/json_serializable.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+pub trait JsonSerializable: Serialize + for<'de> Deserialize<'de> {
+    /// Converts the struct to a string JSON object.
+    ///
+    /// ## Returns
+    /// The struct as a string in a JSON format.
+    fn to_json(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+
+    /// Converts from JSON String into a struct.
+    ///
+    /// ## Arguments
+    /// * input: The string input containing serialized json of the struct.
+    ///
+    /// ## Returns
+    /// The json string converted to a struct.
+    fn from_json(string: &str) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        serde_json::from_str(string).ok()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod json_serializable;
 mod menu;
 mod sound;
 mod storage;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,6 +14,8 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
+use crate::json_serializable::JsonSerializable;
+
 /// Using the `home` crate, finds the home folder for the current user.
 ///
 /// ## Returns
@@ -56,6 +58,8 @@ pub struct Storage {
     folder: String,
 }
 
+impl JsonSerializable for Session {}
+
 impl Session {
     /// Creates a new instance of the Session struct.
     ///
@@ -83,29 +87,9 @@ impl Session {
             },
         }
     }
-
-    // NOTE: This might not be needed.
-    /// Converts the Session instance to a JSON string.
-    ///
-    /// ## Returns
-    /// A string containing a JSON formatted string containing the informations
-    /// contained within the instance.
-    #[allow(dead_code)]
-    pub fn to_json(&self) -> String {
-        serde_json::to_string(&self).unwrap()
-    }
-
-    // NOTE: This might not be needed.
-    /// Takes a JSON string and converts it to an instance of Session
-    ///
-    /// ## Returns
-    /// * Some(Session) if successfull
-    /// * None if unsuccessfull
-    #[allow(dead_code)]
-    pub fn from_json(string: &str) -> Option<Self> {
-        serde_json::from_str(string).ok()
-    }
 }
+
+impl JsonSerializable for SessionList {}
 
 impl SessionList {
     /// Initializes a new empty SessionList struct.
@@ -132,25 +116,6 @@ impl SessionList {
     /// * session: A Session instance to be added to the `sessions` field.
     pub fn append(&mut self, session: Session) {
         self.sessions.push(session);
-    }
-
-    /// Converts the struct to a string JSON object.
-    ///
-    /// ## Returns
-    /// The struct as a string in a JSON format.
-    pub fn to_json(&self) -> String {
-        serde_json::to_string(&self).unwrap()
-    }
-
-    /// Converts from JSON String into a SessionList struct.
-    ///
-    /// ## Arguments
-    /// * input: The string input containing json of SessionList
-    ///
-    /// ## Returns
-    /// The json string converted to a `SessionList` struct.
-    pub fn from_json(input: &str) -> Option<Self> {
-        serde_json::from_str(input).ok()
     }
 
     /// Gets the total amount of minutes worked from all Session instances

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -3,6 +3,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use std::thread;
 use std::time::Duration;
 
+use crate::json_serializable::JsonSerializable;
 use crate::sound::*;
 use crate::storage::Session;
 use crate::storage::SessionList;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
 use crate::{
+    json_serializable::JsonSerializable,
     menu,
     storage::{SessionList, Storage},
     timers::{self, Timer},


### PR DESCRIPTION
Implemented a reusable `JsonSerializable` trait for JSON Serialization and Deseriailization using Serde.

This removes duplicates of to_json and from_json, instead just taking from the trait now.

This closes #16.