### PR TITLE
Tests for `session.rs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Code coverage
+coverage/
+lcov.info
+profile*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ serde = {version = "1.0.217", features = ["derive"]}
 serde_json = "1.0"
 chrono = {version = "0.4.39", features = ["serde"]}
 home = "0.5.11"
+
+[profile.test]
+opt-level = 0

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,10 @@
-[tasks.clean]
-description = "Clean the project"
-command = "cargo"
-args = ["clean"]
+[tasks.clean-coverage]
+description = "Clean the project and remove extra coverage files"
+script = [
+    "cargo clean",
+    "rm -f profile-*",
+    "rm -rf coverage"
+]
 
 [tasks.run-tests]
 description = "Run tests with coverage instrumentation"
@@ -27,4 +30,4 @@ args = [
 
 [tasks.coverage-grcov]
 description = "Run full coverage process (clean, test, and generate grcov report)"
-dependencies = ["clean", "run-tests", "generate-coverage"]
+dependencies = ["clean-coverage", "run-tests", "generate-coverage"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,31 @@
+
+[tasks.clean]
+description = "Clean the project"
+command = "cargo"
+args = ["clean"]
+
+[tasks.run-tests]
+description = "Run tests with coverage instrumentation"
+command = "cargo"
+args = ["test"]
+[tasks.run-tests.env]
+CARGO_TARGET_DIR = "target"
+RUSTFLAGS = "-C instrument-coverage"
+LLVM_PROFILE_FILE = "profile-%p-%m.profraw"
+
+[tasks.generate-coverage]
+description = "Generate HTML coverage report"
+command = "grcov"
+args = [
+    ".",
+    "--binary-path", "target/debug/deps",
+    "--source-dir", ".",
+    "--output-type", "html",
+    "--output-path", "coverage",
+    "--branch",
+    "--ignore-not-existing"
+]
+
+[tasks.coverage]
+description = "Run full coverage process (clean, test, and generate report)"
+dependencies = ["clean", "run-tests", "generate-coverage"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,3 @@
-
 [tasks.clean]
 description = "Clean the project"
 command = "cargo"
@@ -14,7 +13,7 @@ RUSTFLAGS = "-C instrument-coverage"
 LLVM_PROFILE_FILE = "profile-%p-%m.profraw"
 
 [tasks.generate-coverage]
-description = "Generate HTML coverage report"
+description = "Generate HTML coverage report using grcov"
 command = "grcov"
 args = [
     ".",
@@ -26,6 +25,6 @@ args = [
     "--ignore-not-existing"
 ]
 
-[tasks.coverage]
-description = "Run full coverage process (clean, test, and generate report)"
+[tasks.coverage-grcov]
+description = "Run full coverage process (clean, test, and generate grcov report)"
 dependencies = ["clean", "run-tests", "generate-coverage"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
+<div align="center">
+
 # Tomato
+
+[![Coverage Status](https://coveralls.io/repos/github/PlotoZypresse/Tomato/badge.svg)](https://coveralls.io/github/PlotoZypresse/Tomato)
+
+</div>
+
 Tomato is rust based pomodoro timer that lives in your terminal.
 
 Right now you can edit the default work and break time to your liking. The default is 25/5. You can start the timer and you have a visual indication of how much time has passed. You can see how many minutes and seconds are left in the current session. You can see how many minutes you have worked this session. It also plays a sound when the work and break timers are done.

--- a/src/session.rs
+++ b/src/session.rs
@@ -100,9 +100,7 @@ impl SessionList {
     /// ## Returns
     /// * A SessionList struct containing all previous sessions stored in
     ///   `sessions.json`.
-    pub fn load_sessions() -> SessionList {
-        let folder = String::from(".tomato");
-        let file_name = String::from("sessions.json");
+    pub fn load_sessions(folder: String, file_name: String) -> SessionList {
         let storage = Storage::new(Some(folder), file_name.clone());
         let contents = storage.read().unwrap_or_else(|_| "ERR".to_string());
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -46,10 +46,7 @@ impl Settings {
     /// ## Returns
     /// * A Setting struct containing all previous sessions stored in
     ///   `settings.json`.
-    pub fn load_settings() -> Settings {
-        let folder = String::from(".tomato");
-        let file_name = String::from("settings.json");
-
+    pub fn load_settings(folder: String, file_name: String) -> Settings {
         let storage = Storage::new(Some(folder), file_name.clone());
 
         let contents = storage.read().unwrap_or_else(|_| {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,7 +15,7 @@ use home::home_dir;
 ///
 /// ## Returns
 /// The home directory. Panics if this cannot be found.
-fn get_home_path_with<F>(home_dir_fn: F) -> String
+pub fn get_home_path_with<F>(home_dir_fn: F) -> String
 where
     F: Fn() -> Option<PathBuf>,
 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,8 +10,9 @@ use crossterm::{cursor, execute, terminal};
 use std::io;
 
 pub fn ui_loop() {
-    let mut sessions = SessionList::load_sessions();
-    let mut settings = Settings::load_settings();
+    let mut sessions =
+        SessionList::load_sessions(".tomato".to_string(), "sessions.json".to_string());
+    let mut settings = Settings::load_settings(".tomato".to_string(), "sessions.json".to_string());
 
     loop {
         if ui(&mut sessions, &mut settings) == 9 {


### PR DESCRIPTION
We've gained what I believe is full code coverage on `session.rs`. However, it complains about the derives in the actual `Session` struct. I have attempted to test all of them, but it still complains. 

Furthermore, this pull request adds a `Makefile` using [cargo make](https://github.com/sagiegurari/cargo-make) to generate coverage report. 