### PR TITLE
Show hours, days and minutes worked in stats.

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -176,12 +176,21 @@ pub fn start_cycle(timer: &mut Timer, sessions: &mut SessionList, settings: &mut
 pub fn stats(timer: &mut Timer) {
     let minutes = timer.total_worked_minutes;
 
+    println!("Minutes: {minutes}");
+
+    println!(
+        "You've worked for {} days, {} hours and {} minutes.",
+        (minutes / (60 * 24)), // Automatically rounds down
+        (minutes % (60 * 24)) / 60,
+        minutes % 60
+    );
+
     if minutes == 0 {
-        println!("You've worked for 0 minutes in total! It's almost better than nothing!");
+        println!("It's almost better than nothing!");
     } else if minutes <= 25 {
-        println!("You've worked for {minutes} minutes in total! It's better than nothing!");
+        println!("It's better than nothing!");
     } else {
-        println!("You've worked for {minutes} minutes! Good job!");
+        println!("Good job!");
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -176,8 +176,6 @@ pub fn start_cycle(timer: &mut Timer, sessions: &mut SessionList, settings: &mut
 pub fn stats(timer: &mut Timer) {
     let minutes = timer.total_worked_minutes;
 
-    println!("Minutes: {minutes}");
-
     println!(
         "You've worked for {} days, {} hours and {} minutes.",
         (minutes / (60 * 24)), // Automatically rounds down


### PR DESCRIPTION
upgrade from only showing minutes worked. still shows relevant message according to how much you've worked:)